### PR TITLE
Fix forecasting graph logic

### DIFF
--- a/main2+gemini.py
+++ b/main2+gemini.py
@@ -2474,8 +2474,11 @@ class MedicalAnalysisSystem:
             monthly_data = data.resample('MS', on='Дата')['Количество'].sum()
 
             if (monthly_data > 0).sum() < 24:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для SARIMA (нужно минимум 24 месяца)")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для SARIMA (нужно минимум 24 месяца)"
+                )
+                # Продолжаем построение прогноза даже при небольшом числе данных
 
             monthly_data = monthly_data[monthly_data > 0]
             
@@ -2664,8 +2667,11 @@ class MedicalAnalysisSystem:
             monthly_data = data.resample('MS', on='Дата')['Количество'].sum()
 
             if (monthly_data > 0).sum() < 12:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для XGBoost прогнозирования")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для XGBoost прогнозирования"
+                )
+                # Продолжаем обучение модели несмотря на предупреждение
 
             monthly_data = monthly_data.reset_index()
             monthly_data['Месяц'] = monthly_data['Дата'].dt.month
@@ -2692,8 +2698,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data.dropna()
             
             if len(monthly_data) < 8:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных после обработки для XGBoost модели")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных после обработки для XGBoost модели"
+                )
+                # Пытаемся построить модель даже при малом количестве данных
             
             # Подготовка признаков и целевой переменной
             feature_columns = ['Период', 'Месяц', 'Тренд', 'Лаг_1', 'Лаг_2', 'Лаг_3', 
@@ -2935,8 +2944,11 @@ class MedicalAnalysisSystem:
             monthly_data = data.resample('MS', on='Дата')['Количество'].sum()
 
             if (monthly_data > 0).sum() < 6:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для линейной регрессии")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для линейной регрессии"
+                )
+                # Продолжаем построение модели, несмотря на ограниченные данные
 
             monthly_data = monthly_data[monthly_data > 0]
             
@@ -3080,8 +3092,11 @@ class MedicalAnalysisSystem:
             monthly_data['Период'] = monthly_data['Год'] * 12 + monthly_data['Месяц']
             
             if len(monthly_data) < 12:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для ML прогнозирования (нужно минимум 12 месяцев)")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для ML прогнозирования (нужно минимум 12 месяцев)"
+                )
+                # Не прерываем выполнение, пробуем построить модель на доступных данных
             
             # Создание признаков
             monthly_data['Лаг_1'] = monthly_data['Количество'].shift(1)
@@ -3096,8 +3111,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data.dropna()
             
             if len(monthly_data) < 8:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных после обработки для ML модели")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных после обработки для ML модели"
+                )
+                # Продолжаем выполнение несмотря на предупреждение
             
             # Подготовка признаков и целевой переменной
             feature_columns = ['Период', 'Месяц', 'Лаг_1', 'Лаг_2', 'Скользящее_среднее', 'Сезон_sin', 'Сезон_cos']
@@ -3696,8 +3714,11 @@ class MedicalAnalysisSystem:
                 monthly_data = monthly_data[monthly_data > 0]
                 
                 if len(monthly_data) < 6:
-                    messagebox.showwarning("Предупреждение", "Недостаточно данных для линейной регрессии")
-                    return
+                    messagebox.showwarning(
+                        "Предупреждение",
+                        "Недостаточно данных для линейной регрессии"
+                    )
+                    # Продолжаем выполнение даже при небольшом количестве данных
                 
                 # Подготовка признаков
                 X = np.arange(len(monthly_data)).reshape(-1, 1)

--- a/main2.py
+++ b/main2.py
@@ -2311,8 +2311,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data[monthly_data > 0]
             
             if len(monthly_data) < 24:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для SARIMA (нужно минимум 24 месяца)")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для SARIMA (нужно минимум 24 месяца)"
+                )
+                # Продолжаем построение прогноза даже при малом количестве данных
             
             # Проверка стационарности
             def check_stationarity(timeseries):
@@ -2502,8 +2505,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data.sort_values('Период')
             
             if len(monthly_data) < 12:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для XGBoost прогнозирования")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для XGBoost прогнозирования"
+                )
+                # Продолжаем обучение модели даже при недостатке данных
             
             # Создание расширенных признаков
             monthly_data['Лаг_1'] = monthly_data['Количество'].shift(1)
@@ -2525,8 +2531,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data.dropna()
             
             if len(monthly_data) < 8:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных после обработки для XGBoost модели")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных после обработки для XGBoost модели"
+                )
+                # Пытаемся построить модель даже при малом количестве наблюдений
             
             # Подготовка признаков и целевой переменной
             feature_columns = ['Период', 'Месяц', 'Тренд', 'Лаг_1', 'Лаг_2', 'Лаг_3', 
@@ -2765,8 +2774,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data[monthly_data > 0]
             
             if len(monthly_data) < 6:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для линейной регрессии")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для линейной регрессии"
+                )
+                # Продолжаем несмотря на малое количество данных
             
             # Подготовка признаков (отличается от SARIMA)
             X = np.arange(len(monthly_data)).reshape(-1, 1)
@@ -2908,8 +2920,11 @@ class MedicalAnalysisSystem:
             monthly_data['Период'] = monthly_data['Год'] * 12 + monthly_data['Месяц']
             
             if len(monthly_data) < 12:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных для ML прогнозирования (нужно минимум 12 месяцев)")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных для ML прогнозирования (нужно минимум 12 месяцев)"
+                )
+                # Не прерываем выполнение, строим прогноз на доступных данных
             
             # Создание признаков
             monthly_data['Лаг_1'] = monthly_data['Количество'].shift(1)
@@ -2924,8 +2939,11 @@ class MedicalAnalysisSystem:
             monthly_data = monthly_data.dropna()
             
             if len(monthly_data) < 8:
-                messagebox.showwarning("Предупреждение", "Недостаточно данных после обработки для ML модели")
-                return
+                messagebox.showwarning(
+                    "Предупреждение",
+                    "Недостаточно данных после обработки для ML модели"
+                )
+                # Продолжаем обучение даже при ограниченном наборе данных
             
             # Подготовка признаков и целевой переменной
             feature_columns = ['Период', 'Месяц', 'Лаг_1', 'Лаг_2', 'Скользящее_среднее', 'Сезон_sin', 'Сезон_cos']
@@ -3358,8 +3376,11 @@ class MedicalAnalysisSystem:
                 monthly_data = monthly_data[monthly_data > 0]
                 
                 if len(monthly_data) < 6:
-                    messagebox.showwarning("Предупреждение", "Недостаточно данных для линейной регрессии")
-                    return
+                    messagebox.showwarning(
+                        "Предупреждение",
+                        "Недостаточно данных для линейной регрессии"
+                    )
+                    # Продолжаем построение модели даже при ограниченных данных
                 
                 # Подготовка признаков
                 X = np.arange(len(monthly_data)).reshape(-1, 1)


### PR DESCRIPTION
## Summary
- keep forecasting graphs visible even with small datasets
- update data length checks in both main2 variants to warn but continue

## Testing
- `python -m py_compile main2.py main2+gemini.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c586a7dc832682e6ffe67d2f4b91