### PR TITLE
Fix PDF export for unsupported characters

### DIFF
--- a/main2+gemini.py
+++ b/main2+gemini.py
@@ -4158,7 +4158,12 @@ class MedicalAnalysisSystem:
             pdf.add_font('Arial', '', 'C:\\Windows\\Fonts\\arial.ttf', uni=True)
             pdf.set_font('Arial', size=12)
             for line in content.splitlines():
-                pdf.multi_cell(0, 10, txt=line)
+                clean_line = (
+                    line.replace("═", "=")
+                    .replace("║", "|")
+                )
+                clean_line = "".join(ch for ch in clean_line if ord(ch) <= 0xFFFF)
+                pdf.multi_cell(0, 10, txt=clean_line)
             pdf.output(filename)
             messagebox.showinfo("Успех", f"PDF отчет сохранен: {os.path.basename(filename)}")
 

--- a/main2.py
+++ b/main2.py
@@ -3901,7 +3901,12 @@ class MedicalAnalysisSystem:
             pdf.add_font('DejaVu', '', '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf', uni=True)
             pdf.set_font('DejaVu', size=12)
             for line in content.splitlines():
-                pdf.multi_cell(0, 10, txt=line)
+                clean_line = (
+                    line.replace("═", "=")
+                    .replace("║", "|")
+                )
+                clean_line = "".join(ch for ch in clean_line if ord(ch) <= 0xFFFF)
+                pdf.multi_cell(0, 10, txt=clean_line)
             pdf.output(filename)
             messagebox.showinfo("Успех", f"PDF отчет сохранен: {os.path.basename(filename)}")
 


### PR DESCRIPTION
## Summary
- sanitize content before exporting to PDF
- filter out unsupported characters

## Testing
- `python -m py_compile main2.py main2+gemini.py`

------
https://chatgpt.com/codex/tasks/task_e_684a763331788326931a0cb945fcdc4f