### PR TITLE
Remove message about final data availability

### DIFF
--- a/main.py
+++ b/main.py
@@ -1645,9 +1645,6 @@ class MedicalAnalysisSystem:
                 try:
                     date_to_parsed = pd.to_datetime(date_to)
                     if date_to_parsed > available_max:
-                        msg_parts.append(
-                            f"Конечные данные доступны только до {available_max.date()}"
-                        )
                         date_to_parsed = available_max
                     data = data[pd.to_datetime(data['Дата']) <= date_to_parsed]
                 except Exception:


### PR DESCRIPTION
## Summary
- remove info dialog that said final data is only available up to a certain date

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ba6bdd87083269c1f90d7ce146027