### PR TITLE
Fix ax2 definition in SARIMA plot

### DIFF
--- a/main.py
+++ b/main.py
@@ -3022,7 +3022,7 @@ class MedicalAnalysisSystem:
                     r2 = None
 
             # Создание графика
-            fig, ax1 = plt.subplots(1, 1, figsize=(12, 7))
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 7))
             
             # График 1: Прогноз
             ax1.plot(monthly_data.index, monthly_data.values, 


### PR DESCRIPTION
## Summary
- prevent `ax2` undefined error during SARIMA forecast plotting

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba71f297c8326b4493124a07d3273